### PR TITLE
safer directory permissions

### DIFF
--- a/build_platform.sh
+++ b/build_platform.sh
@@ -44,7 +44,7 @@ function build_platform {
     cp ../build_platform/linux/components/$LIB_NAME xpi/components
     cp ../build_platform/linux64/components/$LIB_NAME xpi/components/libnstidy64.so
     cp ../build_platform/linux/components/nstidy.xpt xpi/components
-    chmod 777 xpi/components/libnstidy64.so
+    chmod 755 xpi/components/libnstidy64.so
   else
     cp ../build_platform/$1/components/$LIB_NAME xpi/components
     cp ../build_platform/$1/components/nstidy.xpt xpi/components


### PR DESCRIPTION
it seems unlikely that '777' is appropriate, as it would persist and ally arbitrary content to be written in thsat directory by others at a later date.  Revise to conventional 'owning user' only as to writes

I need to audit more fully and will do so in a clone of this archive 

Thank you